### PR TITLE
make important log about aggregated resources more readable

### DIFF
--- a/storm/src/main/storm/mesos/MesosNimbus.java
+++ b/storm/src/main/storm/mesos/MesosNimbus.java
@@ -477,7 +477,7 @@ public class MesosNimbus implements INimbus {
                                                  .setName(resourceType.toString())
                                                  .setType(Protos.Value.Type.SCALAR)
                                                  .setScalar(Scalar.newBuilder().setValue(scalarResourceEntry.getValue()));
-      if (resourceEntry.getReservationType() != null && resourceEntry.getReservationType().equals(ReservationType.STATICALLY_RESERVED)) {
+      if (resourceEntry.getReservationType() != null && resourceEntry.getReservationType().equals(ReservationType.STATIC)) {
         resourceBuilder.setRole(MesosCommon.getRole(mesosStormConf));
       }
       retVal.add(resourceBuilder.build());
@@ -496,7 +496,7 @@ public class MesosNimbus implements INimbus {
                                                .setName(resourceType.toString())
                                                .setType(Protos.Value.Type.RANGES)
                                                .setRanges(rangesBuilder.build());
-    if (rangeResourceEntry.getReservationType() != null && rangeResourceEntry.getReservationType().equals(ReservationType.STATICALLY_RESERVED)) {
+    if (rangeResourceEntry.getReservationType() != null && rangeResourceEntry.getReservationType().equals(ReservationType.STATIC)) {
       resourceBuilder.setRole(MesosCommon.getRole(mesosStormConf));
     }
     return resourceBuilder.build();

--- a/storm/src/main/storm/mesos/resources/AggregatedOffers.java
+++ b/storm/src/main/storm/mesos/resources/AggregatedOffers.java
@@ -69,7 +69,7 @@ public class AggregatedOffers {
     for (Protos.Resource r : offer.getResourcesList()) {
       ResourceType resourceType = ResourceType.of(r.getName());
       ReservationType reservationType = (r.getRole().equals("*")) ?
-                                        ReservationType.UNRESERVED : ReservationType.STATICALLY_RESERVED;
+                                        ReservationType.UNRESERVED : ReservationType.STATIC;
 
       if (r.hasReservation()) {
         // skip resources with dynamic reservations
@@ -152,8 +152,10 @@ public class AggregatedOffers {
 
   @Override
   public String toString() {
-    return String.format("cpu : %s, memory: %s, ports : %s", availableResources.get(ResourceType.CPU),
-                         availableResources.get(ResourceType.MEM), availableResources.get(ResourceType.PORTS));
+    return String.format("%s, %s, %s",
+                         availableResources.get(ResourceType.CPU),
+                         availableResources.get(ResourceType.MEM),
+                         availableResources.get(ResourceType.PORTS));
   }
 
 

--- a/storm/src/main/storm/mesos/resources/RangeResource.java
+++ b/storm/src/main/storm/mesos/resources/RangeResource.java
@@ -35,6 +35,7 @@ public final class RangeResource implements Resource<RangeResourceEntry> {
   public final ResourceType resourceType;
   private final Map<ReservationType, List<RangeResourceEntry>> availableResourcesByReservationType;
 
+  // XXX(eweathers): this is *so* close to the implementation in ScalarResource constructor.  I feel like there should be a better way of handling this.
   public RangeResource(ResourceType resourceType) {
     this.resourceType = resourceType;
     availableResourcesByReservationType = new TreeMap<>(new DefaultReservationTypeComparator());
@@ -195,11 +196,11 @@ public final class RangeResource implements Resource<RangeResourceEntry> {
         rangeStrings.add(String.format("%s-%s", beginStr, endStr));
       }
     }
-    return String.format("[%s]", StringUtils.join(rangeStrings, ","));
+    return String.format("%s: [%s]", resourceType.toString(), StringUtils.join(rangeStrings, ","));
   }
 
   public String toString(ReservationType reservationType) {
-    return String.format("%s : %s", reservationType, toString(availableResourcesByReservationType.get(reservationType)));
+    return String.format("%s: %s", reservationType, toString(availableResourcesByReservationType.get(reservationType)));
   }
 
   public String toString() {

--- a/storm/src/main/storm/mesos/resources/ReservationType.java
+++ b/storm/src/main/storm/mesos/resources/ReservationType.java
@@ -19,6 +19,10 @@ package storm.mesos.resources;
 
 public enum ReservationType {
   UNRESERVED,
-  STATICALLY_RESERVED,
-  DYNAMICALLY_RESERVED;
+  STATIC,
+  DYNAMIC;
+
+  public String toString() {
+    return name().toLowerCase();
+  }
 }

--- a/storm/src/main/storm/mesos/resources/ScalarResource.java
+++ b/storm/src/main/storm/mesos/resources/ScalarResource.java
@@ -39,7 +39,6 @@ public class ScalarResource implements Resource<ScalarResourceEntry> {
   public ScalarResource(ResourceType resourceType) {
     this.resourceType = resourceType;
     availableResourcesByReservationType = new TreeMap<>(new DefaultReservationTypeComparator());
-
     for (ReservationType reservationType : ReservationType.values()) {
       availableResourcesByReservationType.put(reservationType, new ScalarResourceEntry(reservationType, 0.0));
     }
@@ -129,10 +128,10 @@ public class ScalarResource implements Resource<ScalarResourceEntry> {
   public String toString() {
     List<String> availableResourcesByResourceTypeList = new ArrayList<>();
     for (Map.Entry<ReservationType, ScalarResourceEntry> entry: availableResourcesByReservationType.entrySet()) {
-      availableResourcesByResourceTypeList.add(String.format("%s : %s", entry.getKey(), entry.getValue().getValue()));
+      availableResourcesByResourceTypeList.add(String.format("%s: %f", entry.getKey(), entry.getValue().getValue()));
     }
-    String tmp = StringUtils.join(", ", availableResourcesByResourceTypeList);
-    return String.format("Resource %s - Total available : %f Total available by reservation type : [ %s ]", resourceType.toString(), totalAvailableResource, tmp);
+    String tmp = StringUtils.join(availableResourcesByResourceTypeList, ", ");
+    return String.format("%s: %f (%s)", resourceType.toString(), totalAvailableResource, tmp);
   }
 
   private List<ResourceEntry> removeAndGet(ScalarResourceEntry scalarResourceEntry, Collection<ReservationType> reservationTypesListByPriority) throws

--- a/storm/src/main/storm/mesos/util/PrettyProtobuf.java
+++ b/storm/src/main/storm/mesos/util/PrettyProtobuf.java
@@ -243,6 +243,6 @@ public class PrettyProtobuf {
 
   public static String offerIDListToString(List<OfferID> offerIDList) {
     List<String> offerIDsAsStrings = Lists.transform(offerIDList, offerIDToStringTransform);
-    return String.format("[ %s ]", StringUtils.join(offerIDsAsStrings, ", "));
+    return String.format("[%s]", StringUtils.join(offerIDsAsStrings, ", "));
   }
 }

--- a/storm/src/test/storm/mesos/MesosCommonTest.java
+++ b/storm/src/test/storm/mesos/MesosCommonTest.java
@@ -348,12 +348,12 @@ public class MesosCommonTest {
     AggregatedOffers aggregatedOffers = aggregatedOffersPerNode.get("h1");
     assertEquals(210, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.CPU), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
     assertEquals(3000, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.MEM), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
-    assertEquals(200, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.CPU, ReservationType.STATICALLY_RESERVED), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
-    assertEquals(2000, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.MEM, ReservationType.STATICALLY_RESERVED), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
-    assertEquals(0, TestUtils.calculateAllAvailableRangeResources(aggregatedOffers, ResourceType.PORTS, ReservationType.STATICALLY_RESERVED).size(), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
+    assertEquals(200, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.CPU, ReservationType.STATIC), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
+    assertEquals(2000, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.MEM, ReservationType.STATIC), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
+    assertEquals(0, TestUtils.calculateAllAvailableRangeResources(aggregatedOffers, ResourceType.PORTS, ReservationType.STATIC).size(), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
     aggregatedOffers = aggregatedOffersPerNode.get("h2");
-    assertEquals(0, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.CPU, ReservationType.STATICALLY_RESERVED), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
-    assertEquals(0, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.MEM, ReservationType.STATICALLY_RESERVED), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
+    assertEquals(0, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.CPU, ReservationType.STATIC), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
+    assertEquals(0, TestUtils.calculateAllAvailableScalarResources(aggregatedOffers, ResourceType.MEM, ReservationType.STATIC), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
     assertEquals(100, TestUtils.calculateAllAvailableRangeResources(aggregatedOffers, ResourceType.PORTS, ReservationType.UNRESERVED).size(), MesosCommonTest.DELTA_FOR_DOUBLE_COMPARISON);
   }
 }

--- a/storm/src/test/storm/mesos/resources/AggregatedOffersTest.java
+++ b/storm/src/test/storm/mesos/resources/AggregatedOffersTest.java
@@ -35,7 +35,7 @@ public class AggregatedOffersTest {
   @Test
   public void testToIgnoreDynamicResources() {
     ScalarResource scalarResource = new ScalarResource(ResourceType.CPU);
-    scalarResource.add(new ResourceEntries.ScalarResourceEntry(100.0), ReservationType.STATICALLY_RESERVED);
+    scalarResource.add(new ResourceEntries.ScalarResourceEntry(100.0), ReservationType.STATIC);
     scalarResource.toString();
 
     // Note that buidOffer adds


### PR DESCRIPTION
Also improve readabiltiy to removing unnecessary verbosity of ReservationType enum identifiers,
and then defining their `toString()` method to use the lowercase version of their id.

These new logs retain the same information, but in half the characters.
We can do even better by stripping out unnecessary trailing 0s from the resources.

Example of original log:

```
2016-06-19T07:55:05.924+0000 s.m.u.MesosCommon [INFO] Available resources at workerhostname: cpu : Resource cpus - Total available : 19.500000 Total available by reservation type : [ , [DYNAMICALLY_RESERVED : 0.0, STATICALLY_RESERVED : 0.0, UNRESERVED : 19.5] ], memory: Resource mem - Total available : 88561.000000 Total available by reservation type : [ , [DYNAMICALLY_RESERVED : 0.0, STATICALLY_RESERVED : 0.0, UNRESERVED : 88561.0] ], ports : [31003-31003,31005-32000]
```

Example of new log:

```
2016-06-19T09:21:43.075+0000 s.m.u.MesosCommon [INFO] Available resources at workerhostname: cpus: 19.500000 (dynamic: 0.0, static: 0.0, unreserved: 19.5), mem: 72402.000000 (dynamic: 0.0, static: 0.0, unreserved: 72402.0), ports: [31000-31001,31006-32000]
```

Here's an example of those lines slightly more readably set by adding manual wrapping:

```
2016-06-19T07:55:05.924+0000 s.m.u.MesosCommon [INFO] Available resources at workerhostname: 
  cpu: Resource cpus - Total available : 19.500000 Total available by reservation type : [ , [DYNAMICALLY_RESERVED : 0.0, STATICALLY_RESERVED : 0.0, UNRESERVED : 19.5] ], 
  memory: Resource mem - Total available : 88561.000000 Total available by reservation type : [ , [DYNAMICALLY_RESERVED : 0.0, STATICALLY_RESERVED : 0.0, UNRESERVED : 88561.0] ],
  ports : [31003-31003,31005-32000]
```

Example of new log:

```
2016-06-19T09:21:43.075+0000 s.m.u.MesosCommon [INFO] Available resources at workerhostname: 
  cpus: 19.500000 (dynamic: 0.0, static: 0.0, unreserved: 19.5), 
  mem: 72402.000000 (dynamic: 0.0, static: 0.0, unreserved: 72402.0), 
  ports: [31000-31001,31006-32000]
```
